### PR TITLE
Potential fix for code scanning alert no. 3: Exposure of private information

### DIFF
--- a/freshfarm/Services/EmailService.cs
+++ b/freshfarm/Services/EmailService.cs
@@ -18,6 +18,13 @@ namespace freshfarm.Services
             _logger = logger;
         }
 
+        private string MaskEmail(string email)
+        {
+            var atIndex = email.IndexOf('@');
+            if (atIndex <= 1) return email; // Not enough characters to mask
+            return email.Substring(0, 1) + new string('*', atIndex - 1) + email.Substring(atIndex);
+        }
+
         public async Task SendEmailAsync(string email, string subject, string message, bool isHtml = true)
         {
             try
@@ -49,7 +56,7 @@ namespace freshfarm.Services
                 mailMessage.To.Add(email);
 
                 await smtpClient.SendMailAsync(mailMessage);
-                _logger.LogInformation($"✅ Email successfully sent to {email} with subject: {subject}");
+                _logger.LogInformation($"✅ Email successfully sent to {MaskEmail(email)} with subject: {subject}");
             }
             catch (SmtpException smtpEx)
             {
@@ -57,7 +64,7 @@ namespace freshfarm.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError($"❌ Unexpected error sending email to {email}: {ex.Message}");
+                _logger.LogError($"❌ Unexpected error sending email to {MaskEmail(email)}: {ex.Message}");
             }
         }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Lumenace/freshfarm/security/code-scanning/3](https://github.com/Lumenace/freshfarm/security/code-scanning/3)

To fix the problem, we should avoid logging the email address directly. Instead, we can log a masked version of the email address or use a unique identifier that does not expose private information. This way, we can still have useful logs for debugging and auditing without exposing sensitive information.

The best way to fix the problem without changing existing functionality is to mask the email address before logging it. We can create a helper method to mask the email address and use this method in the logging statements.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
